### PR TITLE
Add popcontext method for "rolling back" (useful for things like beam search)

### DIFF
--- a/ctransformers/llm.py
+++ b/ctransformers/llm.py
@@ -170,6 +170,9 @@ def load_library(path: Optional[str] = None) -> Any:
     ]
     lib.ctransformers_llm_sample.restype = c_int
 
+    lib.ctransformers_llm_pop_context.argtypes = [llm_p]
+    lib.ctransformers_llm_reset.restype = None
+    
     lib.ctransformers_llm_reset.argtypes = [llm_p]
     lib.ctransformers_llm_reset.restype = None
 
@@ -372,6 +375,10 @@ class LLM:
             last_n_tokens,
             seed,
         )
+    
+    def popcontext(self) -> None:
+        """Pops one token off the end of the context."""
+        self.ctransformers_llm_pop_context()
 
     def reset(self) -> None:
         """Resets the model state."""

--- a/ctransformers/llm.py
+++ b/ctransformers/llm.py
@@ -171,7 +171,7 @@ def load_library(path: Optional[str] = None) -> Any:
     lib.ctransformers_llm_sample.restype = c_int
 
     lib.ctransformers_llm_pop_context.argtypes = [llm_p]
-    lib.ctransformers_llm_reset.restype = None
+    lib.ctransformers_llm_pop_context.restype = None
     
     lib.ctransformers_llm_reset.argtypes = [llm_p]
     lib.ctransformers_llm_reset.restype = None

--- a/models/llm.cc
+++ b/models/llm.cc
@@ -96,6 +96,8 @@ int ctransformers_llm_sample(LLM* llm, const int top_k, const float top_p,
   return llm->Sample(top_k, top_p, temperature, repetition_penalty,
                      last_n_tokens, seed);
 }
+  
+void ctransformers_llm_pop_context(LLM* llm) { llm->PopContext(); }
 
 void ctransformers_llm_reset(LLM* llm) { llm->Reset(); }
 

--- a/models/llm.h
+++ b/models/llm.h
@@ -19,6 +19,12 @@ class RingBuffer {
     }
     pos_ = (pos_ + 1) % capacity_;
   }
+ 
+  void Pop() {
+    if (pos_ > 0) {
+      pos_ -= 1;
+    }
+  }
 
   // Returns last n tokens.
   std::unordered_set<gpt_vocab::id> GetRecent(int n) const {
@@ -146,6 +152,10 @@ class LLM {
   virtual int VocabSize() const { return vocab_.id_to_token.size(); }
 
   int ContextLength() const { return n_ctx_; }
+ 
+  void PopContext() {
+   previous_tokens_.Pop();
+  }
 
   void Reset() {
     logits_.clear();

--- a/models/llm.h
+++ b/models/llm.h
@@ -22,7 +22,8 @@ class RingBuffer {
  
   void Pop() {
     if (pos_ > 0) {
-      pos_ -= 1;
+      pos_ = (pos + capacity_ - 1) % capacity_;
+      tokens_.pop_back();
     }
   }
 

--- a/models/llm.h
+++ b/models/llm.h
@@ -22,7 +22,7 @@ class RingBuffer {
  
   void Pop() {
     if (pos_ > 0) {
-      pos_ = (pos + capacity_ - 1) % capacity_;
+      pos_ = (pos_ + capacity_ - 1) % capacity_;
       tokens_.pop_back();
     }
   }

--- a/models/llms/llama.cc
+++ b/models/llms/llama.cc
@@ -102,14 +102,6 @@ class llama_llm : public LLM {
 
   bool Eval(const std::vector<gpt_vocab::id> &tokens, const int threads,
             const int n_past) override {
-   
-    std::cout << "npast " << n_past << std::endl;
-    std::cout << "prompt:" << std::endl;
-    for (int i = 0; i < tokens.size(); i++) {
-      std::cout << ctx_->vocab.id_to_token[tokens[i]].tok;
-    }
-    std::cout << "\n\n" << std::endl;
-   
     const int status =
         llama_eval(ctx_, tokens.data(), tokens.size(), n_past, threads);
     return status == 0;

--- a/models/llms/llama.cc
+++ b/models/llms/llama.cc
@@ -1,4 +1,5 @@
 #include "llm.h"
+#include <iostream>
 
 // https://github.com/ggerganov/llama.cpp/blob/master/examples/main/main.cpp
 
@@ -101,6 +102,12 @@ class llama_llm : public LLM {
 
   bool Eval(const std::vector<gpt_vocab::id> &tokens, const int threads,
             const int n_past) override {
+   
+    std::cout << "prompt:\r\n";
+    for (int i = 0; i < tokens.size(); i++) {
+      std::cout << ctx_->vocab.id_to_token[tokens[i]].tok;
+    }
+   
     const int status =
         llama_eval(ctx_, tokens.data(), tokens.size(), n_past, threads);
     return status == 0;

--- a/models/llms/llama.cc
+++ b/models/llms/llama.cc
@@ -103,10 +103,12 @@ class llama_llm : public LLM {
   bool Eval(const std::vector<gpt_vocab::id> &tokens, const int threads,
             const int n_past) override {
    
-    std::cout << "prompt:\r\n";
+    std::cout << "npast " << n_past << std::endl;
+    std::cout << "prompt:" << std::endl;
     for (int i = 0; i < tokens.size(); i++) {
       std::cout << ctx_->vocab.id_to_token[tokens[i]].tok;
     }
+    std::cout << "\n\n" << std::endl;
    
     const int status =
         llama_eval(ctx_, tokens.data(), tokens.size(), n_past, threads);


### PR DESCRIPTION
This adds a .popcontext() function to the model that pops one token off the end of the context.

Usage: Right now if I have a long prompt and I want to see two different outputs, I have to reparse the prompt:

```
model.reset() # it's stateful so without this the previous llm.evals will impact us
model.eval(model.tokenize([prompt]))
for _ in range(numTokens):
  token = model.llm.sample()
  model.eval([token])
  print(token)

# No way to roll back so I have to redo this initial eval
model.reset()
model.eval(model.tokenize([prompt]))
for _ in range(numTokens):
  token = model.llm.sample()
  model.eval([token])
  print(token)
```

With this change, instead you can do

```
promptTokens = model.tokenize([prompt])
model.reset()
model.eval(promptTokens )
for _ in range(numTokens):
  token = model.llm.sample()
  model.eval([token])
  print(token)

print("rolling back")
for _ in range(numTokens):
  model.popcontext()

# Now we are back to our prompt and can generate from there.
# However, logits won't be correct, so we need to fix those by stepping back one more and eval on the last token in our context
model.popcontext()
model.eval([promptTokens[-1]])
# Now we can generate like normal without needing to parse our prompt again
for _ in range(numTokens):
  token = model.llm.sample()
  model.eval([token])
  print(token)
```

I don't know if this is useful for other ppl/outside the scope of ctransformers, but I needed this functionality to do number extraction (among other things) and I figured I'd share if anyone else was interested.