### PR TITLE
Select inference library using CPU flags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install huggingface-hub pytest
+          pip install huggingface-hub py-cpuinfo pytest
 
       - name: Test
         run: pytest tests --lib ${{ matrix.instructions }}

--- a/ctransformers/lib.py
+++ b/ctransformers/lib.py
@@ -17,11 +17,17 @@ def find_library(path: Optional[str] = None, cuda: bool = False) -> str:
             path = "local"
         elif cuda:
             path = "cuda"
-        elif platform.processor() == "arm":
-            # Apple silicon doesn't support AVX/AVX2.
-            path = "basic" if system == "Darwin" else ""
         else:
-            path = "avx2"
+            from cpuinfo import get_cpu_info
+
+            flags = get_cpu_info()["flags"]
+
+            if "avx2" in flags:
+                path = "avx2"
+            elif "avx" in flags and "f16c" in flags:
+                path = "avx"
+            else:
+                path = "basic"
 
     name = "ctransformers"
     if system == "Linux":

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     package_data={name: ["lib/*/*.so", "lib/*/*.dll", "lib/*/*.dylib"]},
     install_requires=[
         "huggingface-hub",
+        "py-cpuinfo",
     ],
     extras_require={
         "tests": [


### PR DESCRIPTION
This change automatically selects the appropriate compiled version of ggml by checking CPU feature flags. This should address common issues related to "Illegal Instruction" messages.

This works by confirming that the features compiled into the various versions of the ggml module are available on the CPU at runtime. Currently, this means using the `avx2` version if the `avx2` flag is present at runtime, the `avx` version if the `avx` and `f16c` flags are present, and the `basic` version otherwise. This does not explicitly check for `avx` and `f16c` when the `avx2` flag is set, though they are required. I believe that all CPUs with `avx2` support also include `avx` and `f16c` support. It is necessary to explicitly check for `f16c` support, as Sandy Bridge CPUs support `avx` but not `f16c`.

This change does not override manual `lib` selection. If a user with `avx2` support wants to run the `basic` version for whatever reason, this can still be accomplished by setting `lib=basic`. If a user without `avx2` support sets `lib=avx2`, a crash will still occur.