### PR TITLE
Use __path__ instead of __file__ in load_cuda()

### DIFF
--- a/ctransformers/lib.py
+++ b/ctransformers/lib.py
@@ -68,13 +68,7 @@ def load_cuda() -> bool:
         import nvidia
     except ImportError:
         return False
-    if not nvidia.__file__:
-        logger.warning(
-            "CUDA libraries might not be installed properly. "
-            "Please report at https://github.com/marella/ctransformers/issues"
-        )
-        return False
-    path = Path(nvidia.__file__).parent
+    path = Path(nvidia.__path__[0])
     system = platform.system()
     if system == "Windows":
         libs = [


### PR DESCRIPTION
`__file__` is replaced with `__path__` due to `__file__` not being a required attribute of packages.