### PR TITLE
Fix load local GPTQ model bug

### DIFF
--- a/ctransformers/gptq/hub.py
+++ b/ctransformers/gptq/hub.py
@@ -55,7 +55,9 @@ class AutoModelForCausalLM:
 
         model_path = None
         if path_type == "file":
-            model_path = Path(model_path).parent
+            model_path = Path(model_path_or_repo_id).parent
+        elif path_type == "dir" :
+            model_path = Path(model_path_or_repo_id)
         elif path_type == "repo":
             model_path = snapshot_download(
                 repo_id=model_path_or_repo_id,


### PR DESCRIPTION
Fix issue mentioned in [here](https://github.com/marella/ctransformers/issues/79)

In ctransformers/gptq/hub.py line 56-58:
```
        model_path = None
        if path_type == "file":
            model_path = Path(model_path).parent
```

For a local model, the `model_path` variable is `None`, then the parameter for function Path should be `model_path_or_repo_id`. Also, if the user just supplies a model directory, the `path_type` is `dir`, which is not included in the logic. Suggest the code should be changed to the following:

```
        if path_type == "file" :
            model_path = Path(model_path_or_repo_id).parent
        elif path_type == "dir" :
            model_path = Path(model_path_or_repo_id)
```