### PR TITLE
Feat: cache_dir

### DIFF
--- a/ctransformers/hub.py
+++ b/ctransformers/hub.py
@@ -114,6 +114,7 @@ class AutoModelForCausalLM:
         config: Optional[AutoConfig] = None,
         lib: Optional[str] = None,
         local_files_only: bool = False,
+        cache_dir: Optional[str] = None,
         revision: Optional[str] = None,
         hf: bool = False,
         **kwargs,
@@ -131,6 +132,7 @@ class AutoModelForCausalLM:
             (i.e., do not try to download the model).
             revision: The specific model version to use. It can be a branch
             name, a tag name, or a commit id.
+            cache_dir: Cache directory for model, defaults to /.cache
             hf: Whether to create a Hugging Face Transformers model.
 
         Returns:
@@ -169,6 +171,7 @@ class AutoModelForCausalLM:
                 model_path_or_repo_id,
                 model_file,
                 local_files_only=local_files_only,
+                cache_dir = cache_dir,
                 revision=revision,
             )
 
@@ -192,6 +195,7 @@ class AutoModelForCausalLM:
         repo_id: str,
         filename: Optional[str],
         local_files_only: bool,
+        cache_dir: Optional[str] = None,
         revision: Optional[str] = None,
     ) -> str:
         if not filename and not local_files_only:
@@ -204,6 +208,7 @@ class AutoModelForCausalLM:
             repo_id=repo_id,
             allow_patterns=allow_patterns,
             local_files_only=local_files_only,
+            cache_dir=cache_dir,
             revision=revision,
         )
         return cls._find_model_path_from_dir(path, filename=filename)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,9 +1,26 @@
+import os
+import pytest
+import shutil
 from ctransformers import AutoModelForCausalLM
 
+@pytest.fixture
+def temp_folder():
+    # Setup: Create the .temp folder
+    os.makedirs('.temp', exist_ok=False)
+    
+    # This will return control to the test function
+    yield
+    
+    # Teardown: Remove the .temp folder after the test is done
+    shutil.rmtree('.temp')
 
 class TestModel:
-    def test_generate(self, lib):
-        llm = AutoModelForCausalLM.from_pretrained("marella/gpt-2-ggml", lib=lib)
+    def test_generate(self, lib, temp_folder):
+        llm = AutoModelForCausalLM.from_pretrained("marella/gpt-2-ggml", 
+                                                   lib=lib,
+                                                   cache_dir='.temp')
+        assert os.path.exists('.temp'), "Temp file not created."
+        assert os.path.isdir('.temp'), ".Temp file is not a folder"
         response = llm("AI is going to", seed=5, max_new_tokens=3)
         assert response == " be a big"
 


### PR DESCRIPTION
Small QOL change, adding a cache_dir argument to the input of from_pretrained. 

In addition, removes the model after test_model runs, this reduces clutter, but may slow down frequent testing. (This can be removed or modified)

Fixes #132 