### PR TITLE
[AMD] Fix compilation issue with ROCm

### DIFF
--- a/models/ggml/ggml-cuda-ggllm.h
+++ b/models/ggml/ggml-cuda-ggllm.h
@@ -1,3 +1,7 @@
+#ifdef GGML_USE_HIPBLAS
+#define cudaDeviceProp hipDeviceProp_t
+#endif
+
 // https://github.com/cmp-nct/ggllm.cpp/blob/master/ggml-cuda.h
 
 typedef struct {

--- a/models/ggml/libfalcon.cpp
+++ b/models/ggml/libfalcon.cpp
@@ -14,7 +14,11 @@
 #include "ggml.h"
 #include "libfalcon.h"
 #include "llama-util.h"
-#ifdef GGML_USE_CUBLAS
+#ifdef GGML_USE_HIPBLAS
+#include <hip/hip_runtime.h>
+
+#include "ggml-cuda.h"
+#elif GGML_USE_CUBLAS
 #include <cuda_runtime.h>
 
 #include "ggml-cuda.h"


### PR DESCRIPTION
**Problem:**
Unable to install the package on a Linux machine with an AMD 6800XT GPU using ROCm.

```
docker run -it --device=/dev/kfd --device=/dev/dri --group-add video docker.io/rocm/dev-ubuntu-22.04:5.6-complete bash

CT_HIPBLAS=1 pip install ctransformers --no-binary ctransformers

# Compiling after setting CC and CXX env variables also failed with a similar error.
CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ CT_HIPBLAS=1 pip install ctransformers --no-binary ctransformers
```
Error logs: https://gist.github.com/bhargav/7f8c2984ba32ff99ce8e93433d9059a6

**Solution:**
Failures are due to references to CUDA library imports instead of using the HIP versions when compiled for AMD.

Verified that the project can build with the fixes.
```
apt-get update && apt-get install -y git

git clone https://github.com/bhargav/ctransformers.git
cd ctransformers

git checkout bhargav/fix_rocm_compile

CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ CT_HIPBLAS=1 pip install .
```
Build log: https://gist.github.com/bhargav/65bbbd039bda6f39504448656e88ab6b

Package installs successfully and I was able to run a model inference on GPU.