### PR TITLE
recover from `transformers 4.34 refactored`

### DIFF
--- a/ctransformers/transformers.py
+++ b/ctransformers/transformers.py
@@ -81,8 +81,8 @@ class CTransformersModel(PreTrainedModel):
 
 class CTransformersTokenizer(PreTrainedTokenizer):
     def __init__(self, llm: LLM, **kwargs):
-        super().__init__(**kwargs)
         self._llm = llm
+        super().__init__(**kwargs)
 
     @property
     def vocab_size(self) -> int:

--- a/ctransformers/transformers.py
+++ b/ctransformers/transformers.py
@@ -158,3 +158,10 @@ class CTransformersTokenizer(PreTrainedTokenizer):
 
     def convert_tokens_to_string(self, tokens: List[str]) -> str:
         return "".join(tokens)
+
+    # Copied from transformers.models.llama.tokenization_llama.LlamaTokenizer.get_vocab
+    def get_vocab(self):
+        """Returns vocab as a dict"""
+        vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
+        vocab.update(self.added_tokens_encoder)
+        return vocab


### PR DESCRIPTION
this PR is for #154.

I believe  PreTrainedTokenizer `super().__init__(**kwargs)` attempted to use `get_vocab` from LLM but `self._llm = llm` is not yet set, hence it can not access to the LLM.

So I move it down and it works now.

*force-pushed to change author