### PR TITLE
Support for cuda 11.8 and above

### DIFF
--- a/models/ggml/ggml-cuda.cu
+++ b/models/ggml/ggml-cuda.cu
@@ -133,7 +133,7 @@ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
         }                                                                               \
     } while (0)
 
-#if CUDART_VERSION >= 12000
+#if CUDART_VERSION >= 11000
 #define CUBLAS_CHECK(err)                                                               \
     do {                                                                                \
         cublasStatus_t err_ = (err);                                                    \


### PR DESCRIPTION
This change allows CUDA 11.8 users to use ctransformers with GPU support. #90 #170 #139 