### PR TITLE
fix: context_length has no effect

### DIFF
--- a/ctransformers/llm.py
+++ b/ctransformers/llm.py
@@ -562,6 +562,7 @@ class LLM:
             stop = [stop]
 
         tokens = self.tokenize(prompt)
+        max_new_tokens = min(max_new_tokens, self.context_length - len(tokens)
 
         stop_regex = re.compile("|".join(map(re.escape, stop)))
         count = 0


### PR DESCRIPTION
When I ran the model, I found `context_length` has no effect. I try to fix it same as https://github.com/marella/ctransformers/blob/ed02cf4b9322435972ff3566fd4832806338ca3d/ctransformers/gptq/llm.py#L213
